### PR TITLE
logic for showing relevant planet info when a planet is clicked

### DIFF
--- a/solar-system-quackathon/server-side/routes/home.js
+++ b/solar-system-quackathon/server-side/routes/home.js
@@ -5,6 +5,6 @@ import { getPlanets, getMoons } from "../controllers/planets.js";
 // * Handles initial GET request from the homepage
 
 router.get("/", getPlanets); // read
-router.get("/moons", getMoons); // read
+router.get("/moon", getMoons); // read
 
 export default router;

--- a/solar-system-quackathon/src/components/infobox.jsx
+++ b/solar-system-quackathon/src/components/infobox.jsx
@@ -1,5 +1,5 @@
 import "./infobox.css";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Axios from "axios";
 
 export default function InfoBox() {
@@ -11,7 +11,7 @@ export default function InfoBox() {
   const handleClick = async tabName => {
     setActiveTab(tabName);
     try {
-      const response = await Axios.get("/moons");
+      const response = await Axios.get("/moon");
       console.log("data:", response.data);
     } catch (error) {
       console.log(error.response.data);

--- a/solar-system-quackathon/src/components/infobox.jsx
+++ b/solar-system-quackathon/src/components/infobox.jsx
@@ -18,88 +18,80 @@ export default function InfoBox() {
     }
   };
 
-  // const getMoons = async () => {
-  //   try {
-  //     const response = await Axios.get("/api/");
-  //     setMoons(response.data.name);
-  //     console.log(response.data);
-  //   } catch (error) {
-  //     console.log(error.response.data);
-  //   }
-  // };
-
-  // useEffect(() => {})
-
   return (
-    <div className='container'>
-      <div className='tab-container'>
-        <ul className='tabs'>
-          <li
-            onClick={() => handleClick("size")}
-            className={activeTab === "size" ? "bg text-black" : ""}
-          >
-            Size
-          </li>
-          <li
-            onClick={() => handleClick("distance")}
-            className={activeTab === "distance" ? "bg" : ""}
-          >
-            Distance
-          </li>
-          <li
-            onClick={() => handleClick("facts")}
-            className={activeTab === "facts" ? "bg" : ""}
-          >
-            Facts
-          </li>
-          <li
-            onClick={() => handleClick("state")}
-            className={activeTab === "state" ? "bg" : ""}
-          >
-            Gas/Solid
-          </li>
-          <li
-            onClick={() => handleClick("moons")}
-            className={activeTab === "moons" ? "bg" : ""}
-          >
-            Moons
-          </li>
-        </ul>
-      </div>
-      <div className='tab-content'>
-        <div
-          className={`size ${activeTab === "size" ? "fade-in-text" : "hidden"}`}
-        >
-          Size content
+    <div className='planet-facts'>
+      <div className='container'>
+        <div className='tab-container'>
+          <ul className='tabs'>
+            <li
+              onClick={() => handleClick("size")}
+              className={activeTab === "size" ? "bg text-black" : ""}
+            >
+              Size
+            </li>
+            <li
+              onClick={() => handleClick("distance")}
+              className={activeTab === "distance" ? "bg" : ""}
+            >
+              Distance
+            </li>
+            <li
+              onClick={() => handleClick("facts")}
+              className={activeTab === "facts" ? "bg" : ""}
+            >
+              Facts
+            </li>
+            <li
+              onClick={() => handleClick("state")}
+              className={activeTab === "state" ? "bg" : ""}
+            >
+              Gas/Solid
+            </li>
+            <li
+              onClick={() => handleClick("moons")}
+              className={activeTab === "moons" ? "bg" : ""}
+            >
+              Moons
+            </li>
+          </ul>
         </div>
-        <div
-          className={`size ${
-            activeTab === "distance" ? "fade-in-text" : "hidden"
-          }`}
-        >
-          Distance content
-        </div>
-        <div
-          className={`size ${
-            activeTab === "facts" ? "fade-in-text" : "hidden"
-          }`}
-        >
-          Facts content
-        </div>
-        <div
-          className={`size ${
-            activeTab === "state" ? "fade-in-text" : "hidden"
-          }`}
-        >
-          Gas/solid content
-        </div>
-        <div
-          className={`size ${
-            activeTab === "moons" ? "fade-in-text" : "hidden"
-          }`}
-        >
-          Moon(s) content
-          {moons}
+        <div className='tab-content'>
+          <div
+            className={`size ${
+              activeTab === "size" ? "fade-in-text" : "hidden"
+            }`}
+          >
+            Size content
+          </div>
+          <div
+            className={`size ${
+              activeTab === "distance" ? "fade-in-text" : "hidden"
+            }`}
+          >
+            Distance content
+          </div>
+          <div
+            className={`size ${
+              activeTab === "facts" ? "fade-in-text" : "hidden"
+            }`}
+          >
+            Facts content
+          </div>
+          <div
+            className={`size ${
+              activeTab === "state" ? "fade-in-text" : "hidden"
+            }`}
+          >
+            Gas/solid content
+          </div>
+          <div
+            className={`size ${
+              activeTab === "moons" ? "fade-in-text" : "hidden"
+            }`}
+          >
+            Moon(s) content
+            {moons}
+          </div>
         </div>
       </div>
     </div>

--- a/solar-system-quackathon/src/components/placeholder-planets.css
+++ b/solar-system-quackathon/src/components/placeholder-planets.css
@@ -1,3 +1,6 @@
+/* This style is here because the planets in the homepage need to be placed horizontally.
+  But it's not a perfect solution yet.
+*/
 .planets-homepage {
   display: flex;
 }

--- a/solar-system-quackathon/src/components/placeholder-planets.css
+++ b/solar-system-quackathon/src/components/placeholder-planets.css
@@ -1,0 +1,3 @@
+.planets-homepage {
+  display: flex;
+}

--- a/solar-system-quackathon/src/components/placeholder-planets.jsx
+++ b/solar-system-quackathon/src/components/placeholder-planets.jsx
@@ -1,4 +1,12 @@
 import { useNavigate } from "react-router-dom";
+import Mercury from "./planets/mercury";
+import Venus from "./planets/venus";
+import Earth from "../components/planets/earth";
+import Mars from "../components/planets/mars";
+import Jupiter from "../components/planets/jupiter";
+import Saturn from "../components/planets/saturn";
+import Uranus from "../components/planets/uranus";
+import Neptune from "../components/planets/neptune";
 
 export default function Placeholder() {
   const navigate = useNavigate();
@@ -10,19 +18,48 @@ export default function Placeholder() {
       postId = 1;
     } else if (planet === "venus") {
       postId = 2;
+    } else if (planet === "earth") {
+      postId = 3;
+    } else if (planet === "mars") {
+      postId = 4;
+    } else if (planet === "jupiter") {
+      postId = 5;
+    } else if (planet === "saturn") {
+      postId = 6;
+    } else if (planet === "uranus") {
+      postId = 7;
+    } else if (planet === "neptune") {
+      postId = 8;
     }
     navigate(`${planet}/${postId}`);
   };
 
   return (
     <div>
-      <button type='button' onClick={() => handleClick("mercury")}>
-        Mercury
-      </button>
-
-      <button type='button' onClick={() => handleClick("venus")}>
-        Venus
-      </button>
+      <div className='single-planet' onClick={() => handleClick("mercury")}>
+        <Mercury />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("venus")}>
+        <Venus />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("earth")}>
+        <Earth />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("mars")}>
+        <Mars />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("jupiter")}>
+        <Jupiter />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("saturn")}>
+        <Saturn />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("uranus")}>
+        <Uranus />
+      </div>
+      <div className='single-planet' onClick={() => handleClick("neptune")}>
+        <Neptune />
+      </div>
     </div>
   );
 }

--- a/solar-system-quackathon/src/components/placeholder-planets.jsx
+++ b/solar-system-quackathon/src/components/placeholder-planets.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import "./placeholder-planets.css";
 import Mercury from "./planets/mercury";
 import Venus from "./planets/venus";
 import Earth from "../components/planets/earth";
@@ -35,7 +36,7 @@ export default function Placeholder() {
   };
 
   return (
-    <div>
+    <div className='planets-homepage'>
       <div className='single-planet' onClick={() => handleClick("mercury")}>
         <Mercury />
       </div>

--- a/solar-system-quackathon/src/components/planet-container.jsx
+++ b/solar-system-quackathon/src/components/planet-container.jsx
@@ -1,0 +1,43 @@
+/** THIS IS JUST FOR TESTING DURING DEVELOPEMENT.
+ * BUT COULD BE ALSO USED IN PRODUCTION IF WE SO CHOOSE.
+ */
+
+import Mercury from "../components/planets/mercury";
+import Venus from "../components/planets/venus";
+import Earth from "../components/planets/earth";
+import Mars from "../components/planets/mars";
+import Jupiter from "../components/planets/jupiter";
+import Saturn from "../components/planets/saturn";
+import Uranus from "../components/planets/uranus";
+import Neptune from "../components/planets/neptune";
+
+export default function PlanetContainer({ postId }) {
+  return (
+    <div className='planet-container'>
+      <div className={postId === "1" ? "hidden" : ""}>
+        <Mercury />
+      </div>
+      <div className={postId === "2" ? "hidden" : ""}>
+        <Venus />
+      </div>
+      <div className={postId === "3" ? "hidden" : ""}>
+        <Earth />
+      </div>
+      <div className={postId === "4" ? "hidden" : ""}>
+        <Mars />
+      </div>
+      <div className={postId === "5" ? "hidden" : ""}>
+        <Jupiter />
+      </div>
+      <div className={postId === "6" ? "hidden" : ""}>
+        <Saturn />
+      </div>
+      <div className={postId === "7" ? "hidden" : ""}>
+        <Uranus />
+      </div>
+      <div className={postId === "8" ? "hidden" : ""}>
+        <Neptune />
+      </div>
+    </div>
+  );
+}

--- a/solar-system-quackathon/src/index.css
+++ b/solar-system-quackathon/src/index.css
@@ -26,6 +26,7 @@ a:hover {
 body {
   margin: 0;
   display: flex;
+  justify-content: center;
   place-items: center;
   min-width: 320px;
   min-height: 100vh;

--- a/solar-system-quackathon/src/pages/App.jsx
+++ b/solar-system-quackathon/src/pages/App.jsx
@@ -16,6 +16,30 @@ export default function App() {
           path='/venus/:postId'
           element={<PlaceholderInfo planet='venus' />}
         />
+        <Route
+          path='/earth/:postId'
+          element={<PlaceholderInfo planet='earth' />}
+        />
+        <Route
+          path='/mars/:postId'
+          element={<PlaceholderInfo planet='mars' />}
+        />
+        <Route
+          path='/jupiter/:postId'
+          element={<PlaceholderInfo planet='jupiter' />}
+        />
+        <Route
+          path='/saturn/:postId'
+          element={<PlaceholderInfo planet='saturn' />}
+        />
+        <Route
+          path='/uranus/:postId'
+          element={<PlaceholderInfo planet='uranus' />}
+        />
+        <Route
+          path='/neptune/:postId'
+          element={<PlaceholderInfo planet='neptune' />}
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/solar-system-quackathon/src/pages/home.jsx
+++ b/solar-system-quackathon/src/pages/home.jsx
@@ -1,29 +1,12 @@
-import InfoBox from "../components/infobox";
 import Header from "../components/header";
 import Footer from "../components/footer";
 import Placeholder from "../components/placeholder-planets";
-import Mercury from "../components/planets/mercury";
-import Venus from "../components/planets/venus";
-import Earth from "../components/planets/earth";
-import Mars from "../components/planets/mars";
-import Jupiter from "../components/planets/jupiter";
-import Saturn from "../components/planets/saturn";
-import Uranus from "../components/planets/uranus";
-import Neptune from "../components/planets/neptune";
 
 export default function Home() {
   return (
     <>
       <Header />
       <Placeholder />
-      {/* <Mercury />
-      <Venus />
-      <Earth />
-      <Mars />
-      <Jupiter />
-      <Saturn />
-      <Uranus />
-      <Neptune /> */}
       <Footer />
     </>
   );

--- a/solar-system-quackathon/src/pages/home.jsx
+++ b/solar-system-quackathon/src/pages/home.jsx
@@ -16,14 +16,14 @@ export default function Home() {
     <>
       <Header />
       <Placeholder />
-      <Mercury />
+      {/* <Mercury />
       <Venus />
       <Earth />
       <Mars />
       <Jupiter />
       <Saturn />
       <Uranus />
-      <Neptune />
+      <Neptune /> */}
       <Footer />
     </>
   );

--- a/solar-system-quackathon/src/pages/placeholder-info.css
+++ b/solar-system-quackathon/src/pages/placeholder-info.css
@@ -1,0 +1,9 @@
+.planet-page {
+  display: flex;
+}
+
+.planet-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}

--- a/solar-system-quackathon/src/pages/placeholder-info.css
+++ b/solar-system-quackathon/src/pages/placeholder-info.css
@@ -1,3 +1,5 @@
+/* Starting style for this page. Needs to be modified or fleshed out */
+
 .planet-page {
   display: flex;
 }

--- a/solar-system-quackathon/src/pages/placeholder-info.jsx
+++ b/solar-system-quackathon/src/pages/placeholder-info.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import "./placeholder-info.css";
 import { useParams } from "react-router-dom";
 import Axios from "axios";
 import InfoBox from "../components/infobox";
@@ -29,26 +30,32 @@ export default function PlaceholderInfo({ planet }) {
   }, []);
 
   return (
-    <>
-      {postId === "1" ? <Mercury /> : null}
-      {postId === "2" ? <Venus /> : null}
-      {postId === "3" ? <Earth /> : null}
-      {postId === "4" ? <Mars /> : null}
-      {postId === "5" ? <Jupiter /> : null}
-      {postId === "6" ? <Saturn /> : null}
-      {postId === "7" ? <Uranus /> : null}
-      {postId === "8" ? <Neptune /> : null}
-      <div>Hi, I'm {planet}</div>
+    <div className='planet-page'>
+      <div className='activePlanet'>
+        {postId === "1" ? <Mercury /> : null}
+        {postId === "2" ? <Venus /> : null}
+        {postId === "3" ? <Earth /> : null}
+        {postId === "4" ? <Mars /> : null}
+        {postId === "5" ? <Jupiter /> : null}
+        {postId === "6" ? <Saturn /> : null}
+        {postId === "7" ? <Uranus /> : null}
+        {postId === "8" ? <Neptune /> : null}
+      </div>
+      <InfoBox />
+
+      {/** DON'T DELETE BELOW. THIS LOGIC IS NEEDED LATER */}
+      {/* <p>Hi, I'm {planet}</p>
       <p>postId: {postId}</p>
       <p>planet: {planet}</p>
-      {data &&
-        data.map((item, index) => (
-          <div key={index}>
-            <p>{item.body}</p>
-          </div>
-        ))}
-      <InfoBox />
+      <p>
+        {data &&
+          data.map((item, index) => (
+            <div key={index}>
+              <p>{item.body}</p>
+            </div>
+          ))}
+      </p> */}
       <PlanetContainer postId={postId} />
-    </>
+    </div>
   );
 }

--- a/solar-system-quackathon/src/pages/placeholder-info.jsx
+++ b/solar-system-quackathon/src/pages/placeholder-info.jsx
@@ -2,6 +2,15 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Axios from "axios";
 import InfoBox from "../components/infobox";
+import Mercury from "../components/planets/mercury";
+import Venus from "../components/planets/venus";
+import Earth from "../components/planets/earth";
+import Mars from "../components/planets/mars";
+import Jupiter from "../components/planets/jupiter";
+import Saturn from "../components/planets/saturn";
+import Uranus from "../components/planets/uranus";
+import Neptune from "../components/planets/neptune";
+import PlanetContainer from "../components/planet-container";
 
 export default function PlaceholderInfo({ planet }) {
   const [data, setData] = useState(null);
@@ -15,11 +24,20 @@ export default function PlaceholderInfo({ planet }) {
       const data = response.data;
       setData(data);
     };
+    // console.log("postId:", postId);
     fetchData();
   }, []);
 
   return (
     <>
+      {postId === "1" ? <Mercury /> : null}
+      {postId === "2" ? <Venus /> : null}
+      {postId === "3" ? <Earth /> : null}
+      {postId === "4" ? <Mars /> : null}
+      {postId === "5" ? <Jupiter /> : null}
+      {postId === "6" ? <Saturn /> : null}
+      {postId === "7" ? <Uranus /> : null}
+      {postId === "8" ? <Neptune /> : null}
       <div>Hi, I'm {planet}</div>
       <p>postId: {postId}</p>
       <p>planet: {planet}</p>
@@ -30,6 +48,7 @@ export default function PlaceholderInfo({ planet }) {
           </div>
         ))}
       <InfoBox />
+      <PlanetContainer postId={postId} />
     </>
   );
 }


### PR DESCRIPTION
### Description

- When clicking on a planet in the homepage, the user is taken to the planet info page and shows the planet of focus, in addition to the rest of the planets.
- I've added some basic CSS in order to test if the layout we want is possible with the current structure of our elements.
   - please see `placeholder-planets.css` and `placeholder-info.css`. Modify these files as you see fit.
- I've added a new component `planet-container.jsx` to house all the planets. This component has a specific logic applied to it and should only be used on the planet info view, not homepage. I originally created this to test stuff out-- but if we're all happy with how this is working then we can keep this component.

### Visual

Again, just some basic styling using `display:flex`. You'll see that when Mercury is clicked, it is the main focus of the page. Same logic for the other planets.

Feel free to modify the CSS to make it more polished.

![routing5](https://user-images.githubusercontent.com/102492480/229206035-6caea24e-bd2b-4f5e-a633-a3a0247cc93d.gif)


### To-do

- Figure out the logic to take the planet info and place it inside of the infobox component.
- Once the user is on the planet info page, there needs to be a way for them to click on the other planets on the right side of the screen
